### PR TITLE
feat: add cors origins

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+
+What is the background of this pull request?
+
+## Changes
+
+- What are the changes made in this pull request?
+- Change this and that, etc...
+
+## Issues
+
+What are the related issues or stories?

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,0 +1,17 @@
+name: Pull Request Tests
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3   
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 20.x
+    - run: npm ci --no-fund --no-audit
+    - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@govtechsg/dnsprove": "^2.8.0",
         "@middy/core": "^3.4.0",
+        "@middy/http-cors": "^3.4.0",
         "tldts": "^6.1.41",
         "zod": "^3.23.8"
       },
@@ -2995,6 +2996,25 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/@middy/core/-/core-3.6.2.tgz",
       "integrity": "sha512-/vyvG34RIt7CTmuB/jksGkk9vs6RCoOlRFPfdQq11dHkiKlT2mm8j/jZx7gSpEhXXh9LeaEMuKPnsgWBIlGS1g==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@middy/http-cors": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@middy/http-cors/-/http-cors-3.6.2.tgz",
+      "integrity": "sha512-ULsa5TKVsW31s14ctQYTB1YkoMIAGyKc0fhScft6wujL6FCg4U4OxWRVCeviCAegRgyWtYI/fxj1aa4jBgdT4g==",
+      "dependencies": {
+        "@middy/util": "3.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@middy/util": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@middy/util/-/util-3.6.2.tgz",
+      "integrity": "sha512-zjyjF5BdSNnDlZbTvfQwwuUIs3H5PpN/R3wOAipXhaGD/SjpIUBcJJPLUQHySeHoZym1FC3MJYczJDbYQWKWdg==",
       "engines": {
         "node": ">=14"
       }

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "@govtechsg/dnsprove": "^2.8.0",
     "@middy/core": "^3.4.0",
+    "@middy/http-cors": "^3.4.0",
     "tldts": "^6.1.41",
     "zod": "^3.23.8"
   },
-
   "devDependencies": {
     "@serverless/typescript": "^3.0.0",
     "@types/aws-lambda": "^8.10.71",

--- a/src/functions/resolve/cors.ts
+++ b/src/functions/resolve/cors.ts
@@ -1,0 +1,8 @@
+import httpCors from '@middy/http-cors';
+
+export const cors = httpCors({
+    origins: [
+      'https://www.opencerts.io',
+      'https://dev.opencerts.io'
+  ]
+});

--- a/src/functions/resolve/handler.ts
+++ b/src/functions/resolve/handler.ts
@@ -4,6 +4,7 @@ import { queryDns, googleDnsResolver, cloudflareDnsResolver } from "@govtechsg/d
 import { formatJSONResponse } from "@libs/api-gateway";
 import { errorResponse, SchemaValidationError, validateSchema } from "@functions/resolve/helpers";
 import { dnsResultSchema, queryParamSchema } from "@functions/resolve/schemas";
+import { cors } from "@functions/resolve/cors";
 
 const resolve: APIGatewayProxyHandlerV2 = async (event) => {
   try {
@@ -28,4 +29,4 @@ const resolve: APIGatewayProxyHandlerV2 = async (event) => {
   }
 };
 
-export const main = middy(resolve);
+export const main = middy(resolve).use(cors);

--- a/src/functions/resolve/index.ts
+++ b/src/functions/resolve/index.ts
@@ -1,21 +1,16 @@
-import { handlerPath } from '@libs/handler-resolver';
+import { handlerPath } from "@libs/handler-resolver";
 import { AWS } from "@serverless/typescript";
 
-const config: AWS['functions']['Function'] = {
+const config: AWS["functions"]["Function"] = {
   handler: `${handlerPath(__dirname)}/handler.main`,
   events: [
     {
       http: {
-        method: 'get',
-        path: 'resolve',
-        cors: {
-          origin: 'https://www.opencerts.io',
-          headers: ['Accept'],
-          allowCredentials: false,
-        },
+        method: "get",
+        path: "resolve",
       },
     },
   ],
 };
 
-export default config
+export default config;


### PR DESCRIPTION
## Summary

Add CORS origins for `www.opencerts.io` and `dev.opencerts.io`.

## Changes

- Remove CORS in API Gateway
- Add CORS origins for `www.opencerts.io` and `dev.opencerts.io` middy `http-cors`
- Update tests

## Issues

- https://sgts.gitlab-dedicated.com/wog/gvt/gds-ace/general/dlt/galaxies-stories/trustdocs-stories/-/issues/320